### PR TITLE
Use generic download link 

### DIFF
--- a/_entries/3000-software.md
+++ b/_entries/3000-software.md
@@ -10,7 +10,7 @@ The following list of softwares, needs to be installed.
 
 **Work Machine**
 
- - [Teamviewer](https://www.teamviewer.com/en/download/mac/) 
+ - [Teamviewer](https://www.teamviewer.com/en/download) 
  - [Hubstaff](https://app.hubstaff.com/download)
 
 **Work Machine & Phone**


### PR DESCRIPTION
Use generic download link for team viewer, not mac specific 